### PR TITLE
fix broken demo.htm and demo.min.htm

### DIFF
--- a/demo.htm
+++ b/demo.htm
@@ -6,6 +6,7 @@
     <script type="text/javascript" src="src/jquip.docready.js"></script>
     <script type="text/javascript" src="src/jquip.css.js"></script>
     <script type="text/javascript" src="src/jquip.ajax.js"></script>
+    <script type="text/javascript" src="src/jquip.events.js"></script>
     <script type="text/javascript" src="src/jquip.custom.js"></script>
     <script type="text/javascript">
         $(function() {

--- a/demo.min.htm
+++ b/demo.min.htm
@@ -6,6 +6,7 @@
     <script type="text/javascript" src="dist/jquip.docready.min.js"></script>
     <script type="text/javascript" src="dist/jquip.css.min.js"></script>
     <script type="text/javascript" src="dist/jquip.ajax.min.js"></script>
+    <script type="text/javascript" src="dist/jquip.events.min.js"></script>
     <script type="text/javascript" src="dist/jquip.custom.min.js"></script>
     <script type="text/javascript">
         $(function() {


### PR DESCRIPTION
Hi!

The demo page uses $(".attrs button").click(), but jquip.events.js isn't loaded, so .click() isn't defined and clicking the button doesn't work.

I've added jquip.events.js/jquip.events.min.js to demo.htm/demo.min.html

Cheers,
Flo
