### PR TITLE
Fix some Ajax issues

### DIFF
--- a/src/jquip.ajax.js
+++ b/src/jquip.ajax.js
@@ -44,7 +44,7 @@ $['plug']("ajax", function ($) {
 		var xhr = _xhr(), timer, n = 0;
 		if (typeof url === "object") o = url;
 		else o['url'] = url;
-		o = $['_defaults'](o, { 'userAgent': "XMLHttpRequest", 'lang': "en", 'type': "GET", 'data': null, 'contentType': "application/x-www-form-urlencoded", 'dataType': "application/json" });
+		o = $['_defaults'](o, { 'userAgent': "XMLHttpRequest", 'lang': "en", 'type': "GET", 'data': null, 'contentType': "application/x-www-form-urlencoded", 'dataType': null, 'processData': true });
 		if (o.timeout) timer = setTimeout(function () { xhr.abort(); if (o.timeoutFn) o.timeoutFn(o.url); }, o.timeout);
 		var cbCtx = $(o['context'] || document), evtCtx = cbCtx;
 		xhr.onreadystatechange = function() {
@@ -69,14 +69,15 @@ $['plug']("ajax", function ($) {
 		};
 		var url = o['url'], data = null;
 		var isPost = o['type'] == "POST" || o['type'] == "PUT";
-		if (!isPost && o['data']) url += "?" + formData(o['data']);
+		if( o['data'] && o['processData'] && typeof o['data'] == 'object' )
+			data = $['formData'](o['data']);
+
+		if (!isPost && data) url += "?" + data;
 		xhr.open(o['type'], url);
 
-		if (isPost) {
-			var isJson = o['dataType'].indexOf("json") >= 0;
-			data = isJson ? window.JSON.stringify(o['data']) : formData(o['data']);
-			xhr.setRequestHeader("Content-Type", isJson ? "application/json" : "application/x-www-form-urlencoded");
-		}
+		if (isPost)
+			xhr.setRequestHeader("Content-Type", o['contentType']);
+
 		xhr.send(data);
 	} $['ajax'] = ajax;
 	$['getJSON'] = function (url, data, success, error) {


### PR DESCRIPTION
Hello! I've been using jQuip.ajax quite a bit and have come into some issues:
- the `dataType` argument should specify what data type the _response_ is expected to have. The type of the request should be set by `contentType` (which was defined in the defaults but not used anywhere). Currently the code uses `dataType` to modify the type of data _sent_ (i.e., stringifies it if `dataType` is set to `json`), meaning that if you are expecting a `json` response you are forced to send a `json` request - this should not be the case. I've tried to separate the two by making use of `contentType`. 

Note however that the stringify code has been removed altogether - I was thinking on the basis that if the user sets a custom content type then they should be supplying the data in that type, otherwise we assume is is `x-www-form-urlencoded`. If this is going to break backward compatibility then it may need to be reworked.
- the call to formData() for GET requests fails because formData doesn't exist within the current scope. It needed to be wrapped in `$[]`.
- The default dataType is set to `application/json`, which I don't think should be the case. I think we should be using the response headers to work out the data type unless it has been set manually.
