### PR TITLE
Bug Fix for .data(key, value);

### DIFF
--- a/src/jquip.js
+++ b/src/jquip.js
@@ -707,7 +707,7 @@ window['$'] = window['jquip'] = (function(){
 	function data(el, name, setVal){
 		if (!el) return {};
 		if (name && setVal){
-			el.setAttribute(name, setVal);
+			el.setAttribute("data-"+name, setVal);
 			return null;
 		}
 		var o = {};


### PR DESCRIPTION
Setting the data attribute with .data(name, value) misses "data-" in the setAttribute function. This causes a new attribute to be created in the element, while not effecting the original data value.
