### PR TITLE
Only call querySelectorAll on supporting elements

### DIFF
--- a/src/jquip.js
+++ b/src/jquip.js
@@ -560,7 +560,7 @@ window['$'] = window['jquip'] = (function(){
 
 	var useQuery = queryEngines();
 	$['setQuery'](useQuery || function(sel, ctx){
-		return doc.querySelectorAll ? makeArray((ctx || doc).querySelectorAll(sel)) : [];
+		return (ctx = ctx || doc).querySelectorAll ? makeArray(ctx.querySelectorAll(sel)) : [];
 	});
 
 	function loadScript(url, cb, async){

--- a/test/spec/find.js
+++ b/test/spec/find.js
@@ -115,6 +115,14 @@
       expect(ids(res)).toBe('i6,i7');
     });
 
+    it('finds on multi-root document', function() {
+      spyOn(console, 'warn');
+      var res = $('<p>foo</p> <p><i class="yo">bar</i></p>').find('.yo')
+      expect(res.length).toBe(1);
+      expect(res[0].innerText).toBe('bar');
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
     describe('children', function() {
       var template = [
       '<div class="outer">',


### PR DESCRIPTION
This is a fix to issue #31 where querySelectorAll could get called on a text node throwing an error inside of jQuip.
