### PR TITLE
parentsUntil() failing in some conditions

### DIFF
--- a/src/jquip.js
+++ b/src/jquip.js
@@ -937,7 +937,7 @@ window['$'] = window['jquip'] = (function(){
     $['fn'][name] = function(until, sel){
       var ret = map(this, fn, until), args = slice.call(arguments);
       if (!runtil.test(name)) sel = until;
-      if (isS(sel)) ret = filter(sel, ret);
+      if (isS(sel)) ret = makeArray(filter(sel, ret));
 
       ret = this.length > 1 && !guaranteedUnique[name] ? unique(ret) : ret;
       if ((this.length > 1 || rmultiselector.test(sel)) && rparentsprev.test(name)) ret = ret.reverse();


### PR DESCRIPTION
I created a (rather convoluted) example here to reproduct the bug : 
[jquip parentsUntil() failing demo](http://codepen.io/zipang/pen/gJEsl?external-js=https%3A%2F%2Fraw.github.com%2Fmythz%2Fjquip%2Fmaster%2Fsrc%2Fjquip.js) 

I made the following fix: convert ret to Array if we are to call unique(ret) or ret.reverse() in the following lines.
