### PR TITLE
Fix delegate usage of on() binder

### DIFF
--- a/src/jquip.events.js
+++ b/src/jquip.events.js
@@ -132,7 +132,7 @@ $['plug']("events", function($){
   };
 
   p['off'] = function(evt, sel, cb){
-    return typeof sel === 'string' ? this.undelegate(evt, sel, cb) : this.unbind(evt, cb);
+    return typeof sel === 'string' ? this.undelegate(sel, evt, cb) : this.unbind(evt, cb);
   };
     p['trigger'] = function (evt) {
         return this['each'](function () {

--- a/test/spec/events.js
+++ b/test/spec/events.js
@@ -122,7 +122,7 @@
         var spy = jasmine.createSpy('cb'),
             inner = $('<span>').appendTo(el);
 
-        el.on('span', 'click', spy);
+        el.on('click', 'span', spy);
         inner.click();
 
         expect(spy).toHaveBeenCalled();
@@ -132,8 +132,8 @@
         var spy = jasmine.createSpy('cb'),
             inner = $('<span>').appendTo(el);
 
-        el.on('span', 'click', spy);
-        el.off('span', 'click', spy);
+        el.on('click', 'span', spy);
+        el.off('click', 'span', spy);
         inner.click();
 
         expect(spy).not.toHaveBeenCalled();
@@ -144,10 +144,10 @@
             spy2 = jasmine.createSpy('cb2'),
             inner = $('<span>').appendTo(el);
 
-        el.on('span', 'click', spy);
-        el.on('span', 'click', spy2);
+        el.on('click', 'span', spy);
+        el.on('click', 'span', spy2);
 
-        el.off('span', 'click');
+        el.off('click', 'span');
         inner.click();
 
         expect(spy).not.toHaveBeenCalled();


### PR DESCRIPTION
The current usage of on() with a delegate selector is broken. It doesn't use the correct (jQuery) syntax. This should fix it.
